### PR TITLE
Add "CheckForDeviceInCache" function

### DIFF
--- a/framework/microservice_framework.go
+++ b/framework/microservice_framework.go
@@ -1,4 +1,4 @@
-//version 1.1.8
+//version 1.2.8
 
 package framework
 
@@ -8,15 +8,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"reflect"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
-	"runtime/debug"
-	"io"
+
 	"github.com/labstack/echo"
 )
 
@@ -25,19 +26,20 @@ import (
 var UseUDP = false
 var UseTelnet = false
 var KeepAlive = false
-var ConnectTimeout = 5         // seconds
-var ReadTimeout = 5            // seconds
-var TryReadTimeout = 150       // milliseconds
-var WriteTimeout = 5           // seconds
+var ConnectTimeout = 5          // seconds
+var ReadTimeout = 5             // seconds
+var TryReadTimeout = 150        // milliseconds
+var WriteTimeout = 5            // seconds
 var RefreshDataPointsEvery = 50 // seconds (should be 50 after debugging so it's a little faster than the orchestrator gets)
 var KeepRefreshingFor = 300     // seconds (should be 300 after debugging)
 var ReadNoSleepTries = 5
 var MaxReadTries = 6
-var ReadFailSleep = 500 // milliseconds 
+var ReadFailSleep = 500 // milliseconds
 var FunctionStackFull = 100
-var ReportOlderInterval = 120 // seconds (used to throttle function stack errors when network connectivity is gone) 
+var ReportOlderInterval = 120 // seconds (used to throttle function stack errors when network connectivity is gone)
 var DefaultSocketPort int
 var MicroserviceName = ""
+
 // All possible values are "Don't add another instance", "Remove older instance", or "Add another instance"
 // microservices can override this in their own code by setting this global variable
 var CheckFunctionAppendBehavior string = "Don't add another instance"
@@ -54,7 +56,8 @@ var lastQueried = make(map[string]time.Time)
 var lastQueriedMutex sync.Mutex
 var connectionsUDP = make(map[string]*net.UDPConn)
 var connectionsTCP = make(map[string]*net.TCPConn)
-//var connections = make(map[string]*net.Conn) // we'll set this to one of the above at runtime
+
+// var connections = make(map[string]*net.Conn) // we'll set this to one of the above at runtime
 var connectionsMutex sync.Mutex
 var deviceMutexes = make(map[string]sync.Mutex)
 var devicesLock = make(map[string]bool)
@@ -72,20 +75,23 @@ var deviceMutex sync.Mutex
 // Define a type for the callback function
 type MainGetFunc func(socketKey string, setting string, arg1 string, arg2 string) (string, error)
 type MainSetFunc func(socketKey string, setting string, arg1 string, arg2 string, arg3 string) (string, error)
+
 var doDeviceSpecificGet MainGetFunc
 var doDeviceSpecificSet MainSetFunc
 
 // taken from: https://medium.com/@vicky.kurniawan/go-call-a-function-from-string-name-30b41dcb9e12
 type stubMapping map[string]interface{}
+
 var stubStorage = stubMapping{}
 
 // Function to register the main package function
 func RegisterMainGetFunc(fn MainGetFunc) {
-    doDeviceSpecificGet = fn
+	doDeviceSpecificGet = fn
 }
+
 // Function to register the main package function
 func RegisterMainSetFunc(fn MainSetFunc) {
-    doDeviceSpecificSet = fn
+	doDeviceSpecificSet = fn
 }
 
 func registerMicroserviceFunctions(router *echo.Echo) {
@@ -108,18 +114,18 @@ func registerMicroserviceFunctions(router *echo.Echo) {
 }
 
 func index(context echo.Context) error {
-	return context.String(http.StatusOK, "\""+ MicroserviceName +"\"\n")
+	return context.String(http.StatusOK, "\""+MicroserviceName+"\"\n")
 }
 
 func Startup() {
 	function := "Startup"
 	defer func() {
-        if r := recover(); r != nil {
-			retMsg := fmt.Sprintf(function + " - asdf54dgf unhandled panic: %v stack: %v", r, string(debug.Stack()[:]))
-			AddToErrors("all", retMsg) 
-        }
-    }()
-	
+		if r := recover(); r != nil {
+			retMsg := fmt.Sprintf(function+" - asdf54dgf unhandled panic: %v stack: %v", r, string(debug.Stack()[:]))
+			AddToErrors("all", retMsg)
+		}
+	}()
+
 	Log(MicroserviceName + " using OpenAV microservice framework")
 
 	// echo instance
@@ -142,7 +148,7 @@ func Startup() {
 
 func call(socketKey string, funcName string, params ...interface{}) (result interface{}, err error) {
 	function := "call"
-	Log(fmt.Sprintf(function + " - calling: " + funcName + " with %v", params))
+	Log(fmt.Sprintf(function+" - calling: "+funcName+" with %v", params))
 
 	f := reflect.ValueOf(stubStorage[funcName])
 	if len(params) != f.Type().NumIn() {
@@ -178,13 +184,13 @@ func call(socketKey string, funcName string, params ...interface{}) (result inte
 func functionStackProcessor() {
 	function := "functionStackProcessor"
 	defer func() {
-        if r := recover(); r != nil {
-			retMsg := fmt.Sprintf(function + " - bsdf354 unhandled panic: %v stack: %v restarting function stack processor", r, string(debug.Stack()[:]))
-			AddToErrors("all", retMsg) 
+		if r := recover(); r != nil {
+			retMsg := fmt.Sprintf(function+" - bsdf354 unhandled panic: %v stack: %v restarting function stack processor", r, string(debug.Stack()[:]))
+			AddToErrors("all", retMsg)
 			Log("Restarting function stack processor")
 			go functionStackProcessor()
-        }
-    }()
+		}
+	}()
 
 	displayCounter := 100
 	var longerLastReportedTime time.Time
@@ -200,9 +206,9 @@ func functionStackProcessor() {
 			functionStackMutex.Lock()
 			after := false
 			if len(functionStackTimes) == 0 {
-				after = false  // nothing on the stack, so we should stop processing
+				after = false // nothing on the stack, so we should stop processing
 			} else {
-				after = now.After(functionStackTimes[pos])  // true if now is after this timestamp
+				after = now.After(functionStackTimes[pos]) // true if now is after this timestamp
 			}
 			functionStackMutex.Unlock()
 			if after { // now is after the timestamp, so we have an entry that is ready for action
@@ -247,9 +253,9 @@ func functionStackProcessor() {
 				functionStackMutex.Lock()
 				// see if items on our stack are getting too old
 				for i, deadline := range functionStackTimes {
-					if deadline.Add(time.Duration(RefreshDataPointsEvery) * time.Second).Before(time.Now()) { 
+					if deadline.Add(time.Duration(RefreshDataPointsEvery) * time.Second).Before(time.Now()) {
 						// we missed a full refresh cycle and we haven't reported this condition recently
-						if (!longerReported || longerLastReportedTime.Add(time.Duration(ReportOlderInterval) * time.Second).Before(time.Now())) {
+						if !longerReported || longerLastReportedTime.Add(time.Duration(ReportOlderInterval)*time.Second).Before(time.Now()) {
 							longerReported = true
 							longerLastReportedTime = time.Now()
 							errMsg := fmt.Sprintf(function+" -  7980klfad entry number %d on function stack is older than it should be %v compared to %v",
@@ -299,7 +305,7 @@ func functionStackPrepend(toPrepend []string) {
 }
 
 func functionStackInsertAfterUpdates(toInsert []string) {
-	// Add the operation after other update operations.  Used to preserve power on order even if 
+	// Add the operation after other update operations.  Used to preserve power on order even if
 	//   the PUTs come in faster than the microservice can process them.
 
 	now := time.Now()
@@ -307,18 +313,18 @@ func functionStackInsertAfterUpdates(toInsert []string) {
 	functionStackMutex.Lock()
 	// scan past any updates already on the function stack
 	i := 0
-	for (i < len(functionStack) && functionStack[i][0] == "updateDoOnce") {
+	for i < len(functionStack) && functionStack[i][0] == "updateDoOnce" {
 		i++
 	}
 	// Log(fmt.Sprintf("IIIIII: inserted at i = %d", i))
-	if (i == len(functionStack)) {  // nil slice or after last element
+	if i == len(functionStack) { // nil slice or after last element
 		functionStack = append(functionStack, toInsert)
 		functionStackTimes = append(functionStackTimes, deadline)
 	} else {
-		functionStack = append(functionStack[:i + 1], functionStack[i:]...)
+		functionStack = append(functionStack[:i+1], functionStack[i:]...)
 		functionStack[i] = toInsert
 		// Log(fmt.Sprintf("PRE-PENDING to function stack, deadline: %v now: %v", deadline, time.Now()))
-		functionStackTimes = append(functionStackTimes[:i + 1], functionStackTimes[i:]...)
+		functionStackTimes = append(functionStackTimes[:i+1], functionStackTimes[i:]...)
 		functionStackTimes[i] = deadline
 	}
 	functionStackMutex.Unlock()
@@ -423,7 +429,7 @@ func checkFunctionAppend(functionToCall string, endPoint string, socketKey strin
 	} else if CheckFunctionAppendBehavior == "Remove older instance" {
 		if functionToCall == "endPointRefresh" {
 			Log(function + " - leaving older refresh duplicate on function stack and not adding a new one " + socketKey + " " + functionToCall + " " + endPoint + " that exists on the function stack already")
-			return false;
+			return false
 		} else {
 			Log(function + " - replacing older duplicate on function stack " + socketKey + " " + functionToCall + " " + endPoint + " that exists on the function stack already")
 			functionStackRemove(functionToCall, endPoint, socketKey)
@@ -449,13 +455,13 @@ func establishSocketConnectionIfNeeded(socketKey string) bool {
 		if strings.Count(socketKey, "@") == 1 {
 			socketAddress = strings.Split(socketKey, "@")[1]
 		}
-		
+
 		if UseUDP {
 			//We use ListenUDP instead of Dial in case a UDP device responds from a different port than the one we send to.
 			//Seen with Sony cameras.
 			listeningPort := ":" + fmt.Sprint(DefaultSocketPort)
 			locaddr, err := net.ResolveUDPAddr("udp", listeningPort)
-			connection, err := net.ListenUDP("udp",locaddr)
+			connection, err := net.ListenUDP("udp", locaddr)
 			if err != nil {
 				AddToErrors(socketKey, function+" - "+socketKey+" - 423fsdaa error connecting: "+err.Error())
 				return false
@@ -466,7 +472,7 @@ func establishSocketConnectionIfNeeded(socketKey string) bool {
 				Log("establishSocketConnectionIfNeeded - " + socketKey + " - connection successfully established")
 				connectionsUDP[socketKey] = connection
 			}
-		} else {  // TCP
+		} else { // TCP
 			d := net.Dialer{Timeout: time.Duration(ConnectTimeout) * time.Second}
 			connection, err := d.Dial("tcp", socketAddress)
 			if err != nil {
@@ -478,7 +484,7 @@ func establishSocketConnectionIfNeeded(socketKey string) bool {
 			} else {
 				Log("establishSocketConnectionIfNeeded - " + socketKey + " - connection successfully established")
 				connectionsTCP[socketKey] = connection.(*net.TCPConn)
-	
+
 				// TCP success so make a reader
 				global_reader[socketKey] = bufio.NewReader(connectionsTCP[socketKey])
 			}
@@ -511,10 +517,10 @@ func internalCloseSocketConnection(socketKey string) bool {
 		}
 		// Log("internalCloseSocketConnection - " + socketKey + " - connection closed")
 		return true
-	} 
-	// we succeed no matter what - either it was gone already or we closed it or there never 
+	}
+	// we succeed no matter what - either it was gone already or we closed it or there never
 	//     was a connection to close (e.g. Bravia)
-	return true 
+	return true
 }
 
 func WriteLineToSocket(socketKey string, line string) bool {
@@ -556,7 +562,7 @@ func WriteLineToSocket(socketKey string, line string) bool {
 			Log("writeLineToSocket - " + socketKey + " - wrote " + strconv.Itoa(bytesWritten) + " bytes: " + line)
 			return true
 		}
-	} else {  // TCP
+	} else { // TCP
 		err := connectionsTCP[socketKey].SetWriteDeadline(time.Now().Add(time.Duration(WriteTimeout) * time.Second))
 		if err != nil {
 			return addToErrorsAndReturn(socketKey, function+" - "+socketKey+" - can't set write timeout with: "+err.Error(), false)
@@ -599,7 +605,7 @@ func ReadLineFromSocket(socketKey string) string {
 
 	Log(fmt.Sprintf(function+" - "+socketKey+" - 432qfe read : %s in %d tries", msg, tries))
 	return msg
-} 
+}
 
 // This does the work of reading a line with a short timeout.  It can see if there is more pending input from the socket.
 func tryReadLineFromSocket(socketKey string) string {
@@ -618,7 +624,7 @@ func tryReadLineFromSocket(socketKey string) string {
 	var err error = nil
 	data := make([]byte, 1024)
 	var bytesRead = 0
-	if !UseUDP {  // TCP
+	if !UseUDP { // TCP
 		err = connectionsTCP[socketKey].SetReadDeadline(time.Now().Add(time.Duration(TryReadTimeout) * time.Millisecond))
 		if err != nil {
 			AddToErrors(socketKey, function+" - "+socketKey+" - n645ub can't set read timeout with: "+err.Error())
@@ -627,19 +633,19 @@ func tryReadLineFromSocket(socketKey string) string {
 		data, err = global_reader[socketKey].ReadBytes(byte(GlobalDelimiter)) // Read up to the delimiter character
 		//Log(fmt.Sprintf("RRRRRR  read: %v", string(data)))
 		if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
-			Log("tryReadLineFromSocket - " + socketKey + " - nothing to read" )
+			Log("tryReadLineFromSocket - " + socketKey + " - nothing to read")
 			// we expect to reach this case when there is no more from the socket or the device isn't ready yet,
 			//      so timeout here is not an error
 
 			bytesRead = 0
-		} else if (err == nil) {  // succeeded reading something
+		} else if err == nil { // succeeded reading something
 			bytesRead = bytes.Index(data, []byte(string(GlobalDelimiter)))
 			//Log(fmt.Sprintf("RRRRR read %d bytes", bytesRead))
 		} else {
 			AddToErrors(socketKey, function+" - "+socketKey+" - error seeking GlobalDelimiter: "+err.Error())
 			return ""
 		}
-	} else {   // UDP
+	} else { // UDP
 		err = connectionsUDP[socketKey].SetReadDeadline(time.Now().Add(time.Duration(TryReadTimeout) * time.Millisecond))
 		if err != nil {
 			AddToErrors(socketKey, function+" - "+socketKey+" - can't set read timeout with: "+err.Error())
@@ -649,26 +655,26 @@ func tryReadLineFromSocket(socketKey string) string {
 		bytesRead, addr, err = connectionsUDP[socketKey].ReadFromUDP(data) // Read up to the delimiter character
 		if err != nil {
 			AddToErrors(socketKey, function+" - "+socketKey+" - 2131df Error reading: "+err.Error())
-		}else{
+		} else {
 			Log("Read from address: " + addr.String())
 		}
 		//if (err != nil) {
-			//time.Sleep(100)  // sleep to give the remote UDP device a chance to get the packet back
-			//bytesRead, err = connectionsUDP[socketKey].Read(data) // A UDP packet
+		//time.Sleep(100)  // sleep to give the remote UDP device a chance to get the packet back
+		//bytesRead, err = connectionsUDP[socketKey].Read(data) // A UDP packet
 		//}
 	}
 	// Log(fmt.Sprintf("RRRRRR2  read: %v", string(data)))
 	ret := strings.TrimSpace(string(data))
 	// Log("ret is: " + ret)
-	Log(fmt.Sprintf("  " + function + " - "+socketKey+" - read %d bytes: %v", bytesRead, ret))
+	Log(fmt.Sprintf("  "+function+" - "+socketKey+" - read %d bytes: %v", bytesRead, ret))
 
 	if err != nil {
 		if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
 			// we expect to reach this case when there is no more from the socket or the device isn't ready yet,
 			//      so timeout here is not an error
 			// Log("tryReadLineFromSocket - " + socketKey + " - nothing to read" )
-			Log(fmt.Sprintf("  " + function + " - "+socketKey+" - TIMEOUT read : "+ret))
-			if (UseUDP) {
+			Log(fmt.Sprintf("  " + function + " - " + socketKey + " - TIMEOUT read : " + ret))
+			if UseUDP {
 				// Closing connection in case of timeout to let other UDP devices (e.g. VISCA cameras)
 				//  connect with microservice.
 				// Caused by AVer set power not sending a response back.
@@ -685,7 +691,7 @@ func tryReadLineFromSocket(socketKey string) string {
 		if bytesRead == 0 {
 			// we expect to reach this case when there is no more from the socket or the device isn't ready yet,
 			//      so timeout here is not an error
-			Log("tryReadLineFromSocket - " + socketKey + " - nothing to read" )
+			Log("tryReadLineFromSocket - " + socketKey + " - nothing to read")
 			return ""
 		} else {
 			AddToErrors(socketKey, function+" - wrea354 "+socketKey+" - read error: "+err.Error()+" closing socket connection")
@@ -713,19 +719,19 @@ func CheckConnectionsMapExists(socketKey string) bool {
 // and to encapsulate UDP versus TCP connections differences
 // Expected to be used inside the framework. Locking/unlocking happens outside this function.
 func internalConnectionsMapExists(socketKey string) bool {
-	if (UseUDP) {
+	if UseUDP {
 		if _, ok := connectionsUDP[socketKey]; !ok {
 			//Log("q3fasv UDP not connected")
 			return false
 		}
-	} else {   // TCP
+	} else { // TCP
 		if _, ok := connectionsTCP[socketKey]; !ok {
 			//Log("nhh45e456 TCP not connected")
 			return false
 		}
 	}
 	// Log("Socket Key has connection")
-	return true  // if we got here, there is already a map created
+	return true // if we got here, there is already a map created
 }
 
 func Log(text string) {
@@ -801,6 +807,7 @@ func getErrors(context echo.Context) error {
 	// Log( "getErrors - " + socketKey + " - " + strings.Replace(errs, "\n", ", ", -1) )
 	return context.JSON(httpResponseCode, errs)
 }
+
 // Prints the error and adds it the deviceErrors map
 func AddToErrors(socketKey string, errorMessage string) {
 	deviceErrorsMutex.Lock()
@@ -832,11 +839,11 @@ func handleGet(context echo.Context) error {
 
 	socketKey, err := getSocketKey(context)
 	defer func() {
-        if r := recover(); r != nil {
-			retMsg := fmt.Sprintf(function + " - ndh7456 unhandled panic: %v stack: %v", r, string(debug.Stack()[:]))
-			AddToErrors(socketKey, retMsg) 
-        }
-    }()
+		if r := recover(); r != nil {
+			retMsg := fmt.Sprintf(function+" - ndh7456 unhandled panic: %v stack: %v", r, string(debug.Stack()[:]))
+			AddToErrors(socketKey, retMsg)
+		}
+	}()
 	Log("GET " + function + " - " + socketKey + " handling " + endPoint + " get " + arg1 + " " + arg2)
 	if err != nil {
 		AddToErrors("all", function+" - a%&dssd couldn't get a socket key with error: "+err.Error())
@@ -864,7 +871,7 @@ func handleGet(context echo.Context) error {
 			AddToErrors(socketKey, retMsg)
 			delete(deviceStates[socketKey], endPoint) // get the offending value out of the cache so we have a chance to recover
 			retCode = http.StatusNotFound
-		} 
+		}
 		deviceStatesMutex.Unlock()
 	}
 
@@ -893,15 +900,15 @@ func handleGet(context echo.Context) error {
 		}
 	}
 
-	Log(fmt.Sprintf("GET "+function+" - Returning: %v : %v for: " + socketKey + " " + endPoint, retCode, retMsg))
+	Log(fmt.Sprintf("GET "+function+" - Returning: %v : %v for: "+socketKey+" "+endPoint, retCode, retMsg))
 	return context.JSON(retCode, valueMap)
 }
 
-var callDevice = true  // Hack to get around foibles of golang panic processing:
-					// We need side effects (e.g. refresh scheduling) to happen even though we 
-					// panicked in device processing, we still need to finish processing in this function
-					// so we call again and use a global to prevent device processing the second time.
-					// Ugly, but it works.
+var callDevice = true // Hack to get around foibles of golang panic processing:
+// We need side effects (e.g. refresh scheduling) to happen even though we
+// panicked in device processing, we still need to finish processing in this function
+// so we call again and use a global to prevent device processing the second time.
+// Ugly, but it works.
 
 func endPointRefresh(arguments []string) bool {
 	function := "endPointRefresh"
@@ -921,7 +928,7 @@ func endPointRefresh(arguments []string) bool {
 		arg2 = arguments[4]
 	}
 
-	Log( fmt.Sprintf( function + " - arguments are: %v", arguments ) )
+	Log(fmt.Sprintf(function+" - arguments are: %v", arguments))
 
 	// priming data structure
 	deviceStatesMutex.Lock()
@@ -937,15 +944,15 @@ func endPointRefresh(arguments []string) bool {
 
 	deviceMutex.Lock()
 	defer func() {
-        if r := recover(); r != nil {
-			retMsg := fmt.Sprintf(function + " - vsdser546 unhandled panic: %v stack: %v", r, string(debug.Stack()[:]))
-			AddToErrors(socketKey, retMsg) 
-			callDevice = false  // make the recursive call noted above
+		if r := recover(); r != nil {
+			retMsg := fmt.Sprintf(function+" - vsdser546 unhandled panic: %v stack: %v", r, string(debug.Stack()[:]))
+			AddToErrors(socketKey, retMsg)
+			callDevice = false // make the recursive call noted above
 			deviceMutex.Unlock()
 			dataUpdated = endPointRefresh(arguments)
-			callDevice = true  // let the next invocation try the device again
-        }
-    }()	
+			callDevice = true // let the next invocation try the device again
+		}
+	}()
 	var resp string = "unknown"
 	var err error = nil
 	if callDevice {
@@ -974,7 +981,7 @@ func endPointRefresh(arguments []string) bool {
 	// Log(fmt.Sprintf(function + " - NOW: %v LAST QUERIED: %v", time.Now(), lastQueried[socketKey]))
 	// renew the refresh cycle if appropriate
 	if !CheckForEndPointInCache(socketKey, endPoint) ||
-		time.Duration(time.Now().Sub(lastQueried[socketKey])) < time.Duration(time.Duration(KeepRefreshingFor) * time.Second) {
+		time.Duration(time.Now().Sub(lastQueried[socketKey])) < time.Duration(time.Duration(KeepRefreshingFor)*time.Second) {
 		Log(function + " - " + socketKey + " - ef3241 device freshly in use, we'll update it again later")
 		if !refreshError && checkFunctionAppend(function, endPoint, socketKey) {
 			functionStackAppend(append([]string{function, endPoint}, arguments...))
@@ -1000,11 +1007,11 @@ func handleUpdate(context echo.Context) error {
 
 	socketKey, err := getSocketKey(context)
 	defer func() {
-        if r := recover(); r != nil {
-			retMsg := fmt.Sprintf(function + " - lnnui3q23 unhandled panic: %v stack: %v", r, string(debug.Stack()[:]))
-			AddToErrors(socketKey, retMsg) 
-        }
-    }()
+		if r := recover(); r != nil {
+			retMsg := fmt.Sprintf(function+" - lnnui3q23 unhandled panic: %v stack: %v", r, string(debug.Stack()[:]))
+			AddToErrors(socketKey, retMsg)
+		}
+	}()
 
 	Log("PUT " + function + " - " + socketKey + " handling " + endPoint + " update " + arg1 + " " + arg2)
 	if err != nil {
@@ -1036,7 +1043,7 @@ func handleUpdate(context echo.Context) error {
 	if err != nil { // shouldn't ever happen because we successfully unmarshaled it
 		AddToErrors(socketKey, function+" - mfh45gfh couldn't marshal JSON to put into the cache")
 		return context.JSON(http.StatusNotFound, "error marshaling value to put into the cache  43qfsdsfd;")
-	}	
+	}
 	newState := string(newStateBytes)
 	if !strings.Contains(newState, `"`) {
 		// this one is a native JSON type, but we store everything in the cache as quoted strings, so add quotes
@@ -1084,6 +1091,7 @@ func doRelatedActions(socketKey string, setting string, params string) {
 		}
 	}
 }
+
 // Can be called externally to get the cached value for a device endpoint
 func GetDeviceStateEndpoint(socketKey string, endpoint string) string {
 	deviceStatesMutex.Lock()
@@ -1092,6 +1100,7 @@ func GetDeviceStateEndpoint(socketKey string, endpoint string) string {
 
 	return value
 }
+
 // Can be called externally to set the cached value for a device endpoint
 func SetDeviceStateEndpoint(socketKey string, endpoint string, value string) {
 	deviceStatesMutex.Lock()
@@ -1122,12 +1131,12 @@ func updateDoOnce(arguments []string) bool {
 
 	deviceMutex.Lock()
 	defer func() {
-        if r := recover(); r != nil {
-			retMsg := fmt.Sprintf(function + " - bf34fsd unhandled panic: %v stack: %v", r, string(debug.Stack()[:]))
-			AddToErrors(socketKey, retMsg) 
+		if r := recover(); r != nil {
+			retMsg := fmt.Sprintf(function+" - bf34fsd unhandled panic: %v stack: %v", r, string(debug.Stack()[:]))
+			AddToErrors(socketKey, retMsg)
 			deviceMutex.Unlock()
-        }
-    }()
+		}
+	}()
 	resp, err := doDeviceSpecificSet(socketKey, setting, arg1, arg2, arg3)
 	deviceMutex.Unlock()
 	resp = resp // appease
@@ -1162,42 +1171,42 @@ func DoPost(socketKey string, theURL string, jsonReq string) (string, error) {
 		}
 	}
 
-    req, err := http.NewRequest(http.MethodPost, postURL, 
-            bytes.NewBuffer(jsonReqBytes))
-    req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	req, err := http.NewRequest(http.MethodPost, postURL,
+		bytes.NewBuffer(jsonReqBytes))
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 
 	// An apiKey can be passed through as a password in the URL for the microservice.
 	// If none is provided, 1234 is used by default.
-	if password != ""{
+	if password != "" {
 		apiKey = password
 	} else {
 		apiKey = "1234"
 	}
 	// Log("APIKEY: " + apiKey)
-    req.Header.Set("x-auth-psk", apiKey)
-    client := &http.Client{
-        Timeout: 2 * time.Second,
-    }
-    resp, err := client.Do(req)
-    if err != nil {
-		errMsg := fmt.Sprintf(function + " - 423dfsaknnl HTTP client.DO error: %v", err)
-        Log(errMsg)
-		AddToErrors(socketKey, errMsg)
-		return errMsg, err
-    }
- 
-    defer resp.Body.Close()
-    bodyBytes, err := io.ReadAll(resp.Body)
+	req.Header.Set("x-auth-psk", apiKey)
+	client := &http.Client{
+		Timeout: 2 * time.Second,
+	}
+	resp, err := client.Do(req)
 	if err != nil {
-		errMsg := fmt.Sprintf(function + " - 32rqfsada HTTP ioutil.ReadAll error: %v", err)
+		errMsg := fmt.Sprintf(function+" - 423dfsaknnl HTTP client.DO error: %v", err)
 		Log(errMsg)
 		AddToErrors(socketKey, errMsg)
-        return errMsg, err
-    }
+		return errMsg, err
+	}
 
-    // Convert response body to string
-    bodyString := string(bodyBytes)
-    Log("<====== " + function + " - got bodyString: " + bodyString)
+	defer resp.Body.Close()
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		errMsg := fmt.Sprintf(function+" - 32rqfsada HTTP ioutil.ReadAll error: %v", err)
+		Log(errMsg)
+		AddToErrors(socketKey, errMsg)
+		return errMsg, err
+	}
+
+	// Convert response body to string
+	bodyString := string(bodyBytes)
+	Log("<====== " + function + " - got bodyString: " + bodyString)
 
 	return bodyString, nil
 }

--- a/framework/microservice_framework.go
+++ b/framework/microservice_framework.go
@@ -394,6 +394,22 @@ func functionStackExist(functionName string, endPoint string, socketKey string) 
 	return false
 }
 
+func CheckForDeviceInCache(socketKey string) bool {
+	//function := "CheckForDeviceInCache"
+
+	deviceStatesMutex.Lock()
+	defer deviceStatesMutex.Unlock()
+
+	// Log(function + " - socketKey: " + socketKey)
+	if _, ok := deviceStates[socketKey]; !ok {
+		// Log(function + " - " + socketKey + " - first we hear of device")
+		return false // wasn't in cache
+	}
+	// Log(function + " - device was in the cache")
+
+	return true
+}
+
 func CheckForEndPointInCache(socketKey string, endPoint string) bool {
 	// function := "checkForEndPointInCache"
 


### PR DESCRIPTION
Added a function that's almost identical to "CheckForEndPointInCache", but checks if any endpoint is being refreshed for a device.

The Extron microservice I'm working on needs this.  (This is because the microservice needs to close the connection if the framework is not automatically refreshing any endpoint, or else the Extron device closes the connection first, which leads to errors that take some time to recover from the next time an endpoint for the device is refreshed)

Version number was updated with a medium version change.